### PR TITLE
Correct the field type of `EmailActivity`

### DIFF
--- a/src/pytmv1/model/common.py
+++ b/src/pytmv1/model/common.py
@@ -150,7 +150,7 @@ class Endpoint(BaseConsumable):
 
 
 class EmailActivity(BaseConsumable):
-    event_source_type: Optional[str] = None
+    event_source_type: Optional[int] = None
     mail_msg_subject: Optional[str] = None
     mail_msg_id: Optional[str] = None
     msg_uuid: str


### PR DESCRIPTION
The data type of `event_source_type` in [the official document](https://automation.trendmicro.com/xdr/api-v3/#tag/Search/paths/~1v3.0~1search~1identityActivities/get) is now integer, not string:

![image](https://github.com/user-attachments/assets/bbe6500d-92b3-4118-b687-91baff2f548b)
